### PR TITLE
Build C# project after decompiling

### DIFF
--- a/utility/import_exporter.cpp
+++ b/utility/import_exporter.cpp
@@ -464,6 +464,9 @@ Error ImportExporter::export_imports(const String &p_out_dir, const Vector<Strin
 				ERR_PRINT("Failed to decompile C# scripts!");
 				report->failed_scripts.append_array(cs_files);
 			} else {
+				if (!OS::get_singleton()->execute("dotnet", { "build", csproj_path })) {
+					ERR_PRINT("Failed to compile decompiled C# scripts!");
+				}
 				auto failed = decompiler->get_files_not_present_in_file_map();
 				for (int i = 0; i < cs_files.size(); i++) {
 					if (!failed.has(cs_files[i])) {


### PR DESCRIPTION
This fixes the issue of having to build the solution yourself each time you decompile to prevent signals getting lost